### PR TITLE
`options` Accepts Query

### DIFF
--- a/blendsql/_constants.py
+++ b/blendsql/_constants.py
@@ -1,4 +1,5 @@
 from enum import Enum, EnumMeta, auto
+from dataclasses import dataclass
 
 HF_REPO_ID = "parkervg/blendsql-test-dbs"
 
@@ -33,7 +34,8 @@ class IngredientType(str, Enum, metaclass=StrInMeta):
     JOIN = auto()
 
 
-class IngredientKwarg(str, Enum):
+@dataclass
+class IngredientKwarg:
     QUESTION = "question"
     CONTEXT = "context"
     OPTIONS = "options"

--- a/blendsql/ingredients/builtin/llm/qa/main.py
+++ b/blendsql/ingredients/builtin/llm/qa/main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Optional, List
+from typing import Dict, Union, Optional, Set
 
 import pandas as pd
 from blendsql.llms._llm import LLM
@@ -12,7 +12,7 @@ class LLMQA(QAIngredient):
         self,
         question: str,
         llm: LLM,
-        options: Optional[List[str]] = None,
+        options: Optional[Set[str]] = None,
         context: Optional[pd.DataFrame] = None,
         value_limit: Optional[int] = None,
         table_to_title: Optional[Dict[str, str]] = None,

--- a/blendsql/ingredients/ingredient.py
+++ b/blendsql/ingredients/ingredient.py
@@ -312,16 +312,18 @@ class QAIngredient(Ingredient):
                 raise IngredientException("Empty subtable passed to QAIngredient!")
         unpacked_options = options
         if options is not None:
-            try:
-                tablename, colname = utils.get_tablename_colname(options)
-                tablename = kwargs.get("aliases_to_tablenames").get(
-                    tablename, tablename
-                )
-                unpacked_options = self.db.execute_query(
-                    f'SELECT DISTINCT "{colname}" FROM "{tablename}"'
-                )[colname].tolist()
-            except ValueError:
-                unpacked_options = options.split(";")
+            if not isinstance(options, list):
+                try:
+                    tablename, colname = utils.get_tablename_colname(options)
+                    tablename = kwargs.get("aliases_to_tablenames").get(
+                        tablename, tablename
+                    )
+                    unpacked_options = self.db.execute_query(
+                        f'SELECT DISTINCT "{colname}" FROM "{tablename}"'
+                    )[colname].tolist()
+                except ValueError:
+                    unpacked_options = options.split(";")
+            unpacked_options = set(unpacked_options)
         self.num_values_passed += len(subtable) if subtable is not None else 0
         kwargs[IngredientKwarg.OPTIONS] = unpacked_options
         kwargs[IngredientKwarg.CONTEXT] = subtable

--- a/tests/test_multi_table_blendsql.py
+++ b/tests/test_multi_table_blendsql.py
@@ -300,6 +300,42 @@ def test_cte_qa_multi_exec(db, ingredients):
     # assert smoothie.meta.num_values_passed == passed_to_ingredient.values[0].item()
 
 
+def test_cte_qa_named_multi_exec(db, ingredients):
+    blendsql = """
+   {{
+        get_table_size(
+            question='Table size?',
+            context=(
+                WITH a AS (
+                    SELECT * FROM (SELECT DISTINCT * FROM portfolio) as w 
+                        WHERE {{starts_with('F', 'w::Symbol')}} = TRUE
+                ) SELECT * FROM a WHERE LENGTH(a.Symbol) > 2
+            )
+        )
+    }}
+    """
+    sql = """
+    WITH a AS (
+        SELECT * FROM (SELECT DISTINCT * FROM portfolio) as w
+            WHERE w.Symbol LIKE 'F%'
+    ) SELECT COUNT(*) FROM a WHERE LENGTH(a.Symbol) > 2
+    """
+    smoothie = blend(
+        query=blendsql,
+        db=db,
+        ingredients=ingredients,
+    )
+    sql_df = db.execute_query(sql)
+    assert_equality(smoothie=smoothie, sql_df=sql_df, args=["F"])
+    # Make sure we only pass what's necessary to our ingredient
+    # passed_to_ingredient = db.execute_query(
+    #     """
+    # SELECT COUNT(DISTINCT Symbol) FROM portfolio WHERE LENGTH(Symbol) > 3 AND Quantity > 200
+    # """
+    # )
+    # assert smoothie.meta.num_values_passed == passed_to_ingredient.values[0].item()
+
+
 # def test_subquery_alias_with_join_multi_exec(db, ingredients):
 #     blendsql = """
 #     SELECT w."Percent of Account" FROM (SELECT * FROM "portfolio" WHERE Quantity > 200 OR "Today''s Gain/Loss Percent" > 0.05) as w

--- a/tests/test_multi_table_blendsql.py
+++ b/tests/test_multi_table_blendsql.py
@@ -1,8 +1,8 @@
 import pytest
 from blendsql import blend
 from blendsql.db import SQLiteDBConnector
+from blendsql.utils import fetch_from_hub
 from tests.utils import (
-    fetch_from_hub,
     assert_equality,
     starts_with,
     get_length,

--- a/tests/test_single_table_blendsql.py
+++ b/tests/test_single_table_blendsql.py
@@ -1,8 +1,8 @@
 import pytest
 from blendsql import blend
 from blendsql.db import SQLiteDBConnector
+from blendsql.utils import fetch_from_hub
 from tests.utils import (
-    fetch_from_hub,
     assert_equality,
     starts_with,
     get_length,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from typing import Iterable, Any, List, Union
 from blendsql.ingredients import MapIngredient, QAIngredient, JoinIngredient
+from blendsql.db.utils import single_quote_escape
 
 
 class starts_with(MapIngredient):
@@ -24,7 +25,7 @@ class get_length(MapIngredient):
 
 
 class select_first_sorted(QAIngredient):
-    def run(self, question: str, options: List[str], **kwargs) -> Iterable[Any]:
+    def run(self, question: str, options: set, **kwargs) -> Iterable[Any]:
         """Simple test function, equivalent to the following in SQL:
         `ORDER BY {colname} LIMIT 1`
         """
@@ -42,10 +43,19 @@ class return_aapl(QAIngredient):
 
 class get_table_size(QAIngredient):
     def run(
-        self, question: str, context: pd.DataFrame, options: str = None, **kwargs
+        self, question: str, context: pd.DataFrame, options: set = None, **kwargs
     ) -> Union[str, int, float]:
         """Returns the length of the context subtable passed to it."""
         return len(context)
+
+
+class select_first_option(QAIngredient):
+    def run(
+        self, question: str, context: pd.DataFrame, options: set = None, **kwargs
+    ) -> Union[str, int, float]:
+        """Returns the first item in the (ordered) options set"""
+        assert options is not None
+        return f"'{single_quote_escape(sorted(list(options))[0])}'"
 
 
 class do_join(JoinIngredient):


### PR DESCRIPTION
Did a little rework so that the `options` argument can be one of 3 things:

- `{tablename}::{columnname}` string
- String of `;` separated values 
- Another BlendSQL query which returns a set of values

For example, the following is now possible:
```sql
SELECT DISTINCT merchant FROM transactions WHERE
merchant = {{
    LLMQA(
        'Which merchant is most likely to sell italian food?',
        (SELECT merchant FROM transactions),
        options=(SELECT merchant FROM transactions WHERE amount > 100)
    )
}}
```
The selected merchant will now be restricted to the subset where `amount > 100`.

I added `test_query_options_arg` in `test_single_table_blendsql.py` for this change.