### PR TITLE
Integrating `qualify_columns` from sqlglot

### DIFF
--- a/blendsql/_dialect.py
+++ b/blendsql/_dialect.py
@@ -1,6 +1,9 @@
 from sqlglot.dialects import SQLite
 from sqlglot.tokens import TokenType
+from sqlglot.optimizer.qualify_columns import qualify_columns
+from sqlglot.schema import Schema
 from sqlglot import exp, parse_one
+from typing import Union, Optional
 
 
 def glob_to_match(self: SQLite.Generator, expression: exp.Where) -> str:
@@ -23,8 +26,10 @@ class FTS5SQLite(SQLite):
         }
 
 
-def _parse_one(sql: str):
+def _parse_one(sql: str, schema: Optional[Union[dict, Schema]] = None):
     """Utility to make sure we parse/read queries with the correct dialect."""
     # https://www.sqlite.org/optoverview.html
     node = parse_one(sql, dialect=FTS5SQLite)
+    if schema is not None:
+        node = qualify_columns(expression=node, schema=schema)
     return node

--- a/blendsql/_sqlglot.py
+++ b/blendsql/_sqlglot.py
@@ -526,6 +526,8 @@ class SubqueryContextManager:
         """
         Args:
             tablename: The target tablename to search and extract predicates for
+            disambiguate_multi_tables: `True` if we have multiple tables in our subquery,
+                and need to be sure we're only fetching the predicates for the specified `tablename`
         """
         # 2 places conditions can come in here
         # 'WHERE' statement and predicate in a 'JOIN' statement

--- a/blendsql/blendsql.py
+++ b/blendsql/blendsql.py
@@ -404,7 +404,7 @@ def blend(
             in_cte, table_alias_name = is_in_cte(subquery, return_name=True)
             scm = SubqueryContextManager(
                 node=_parse_one(
-                    subquery_str
+                    subquery_str, schema=db.get_sqlglot_schema()
                 ),  # Need to do this so we don't track parents into construct_abstracted_selects
                 prev_subquery_has_ingredient=prev_subquery_has_ingredient,
                 alias_to_subquery={table_alias_name: subquery} if in_cte else None,

--- a/blendsql/db/sqlite_db_connector.py
+++ b/blendsql/db/sqlite_db_connector.py
@@ -71,6 +71,24 @@ class SQLiteDBConnector:
     def create_clause(self, tablename):
         return (tablename, _create_clause(con=self.con, tablename=tablename))
 
+    def get_sqlglot_schema(self) -> dict:
+        """Returns database schema as a dictionary, in the format that
+        sqlglot.optimizer expects.
+
+        Example:
+            >>> {"x": {"A": "INT", "B": "INT", "C": "INT", "D": "INT", "Z": "STRING"}}
+        """
+        schema = {}
+        for tablename in self._iter_tables():
+            schema[tablename] = {}
+            for _, row in self.execute_query(
+                f"""
+            SELECT name, type FROM pragma_table_info('{tablename}')
+            """
+            ).iterrows():
+                schema[tablename]['"' + row["name"] + '"'] = row["type"]
+        return schema
+
     def to_serialized(
         self,
         ignore_tables: Iterable[str] = None,


### PR DESCRIPTION
This PR uses the [qualify_columns](https://sqlglot.com/sqlglot/optimizer/qualify_columns.html#qualify_columns) function from [sqlglot](https://github.com/tobymao/sqlglot) to disambiguate column names referenced in a multi-table environment.

TL;DR:
- Don't need to qualify columns in `{tablename}.{columnname}` format anymore
- Added `test_join_not_qualified_multi_exec` and `test_complex_not_qualified_multi_exec` tests
 
This is useful, since from the below query (taken from the `test_join_multi_exec` test):

```sql
SELECT "Run Date", Account, Action, ROUND("Amount ($)", 2) AS 'Total Dividend Payout ($$)', Name
FROM account_history
LEFT JOIN constituents ON account_history.Symbol = constituents.Symbol
WHERE Sector = 'Information Technology'
AND {{starts_with('A', 'constituents::Name')}} = 1
AND lower(Action) like "%dividend%"
```

We want to recover the following abstracted queries for the 2 tables `constituents` and `account_history` in [`table_star_queries()`](https://github.com/parkervg/blendsql/blob/38639f6cad375958f6a723a97314dc64d3da7bb6/blendsql/_sqlglot.py#L436):

```sql
SELECT * FROM "account_history" WHERE TRUE AND LOWER(account_history.Action) LIKE "%dividend%" AND TRUE AND TRUE

SELECT * FROM "constituents" WHERE TRUE AND TRUE AND constituents.Sector = 'Information Technology' AND TRUE` and setting to `4e8a_constituents_0
```

In order to do this, though, we need to know that the `Sector` column comes from the `constituents` table, and `Action` comes from `account_history`.

Prior to parsing in BlendSQL, we now do that disambiguation so users don't always need to qualify the column references themselves in the `{tablename}.{columnname}` sort of style. If it works in native SQLite, it'll work in BlendSQL. 