### PR TITLE
Caching Fix

### DIFF
--- a/blendsql/_program.py
+++ b/blendsql/_program.py
@@ -7,6 +7,19 @@ from guidance.models import Model, Chat
 from guidance import user, system, assistant
 from contextlib import nullcontext
 import inspect
+import ast
+import textwrap
+
+
+def get_contexts(model: Model):
+    usercontext = nullcontext()
+    systemcontext = nullcontext()
+    assistantcontext = nullcontext()
+    if isinstance(model, Chat):
+        usercontext = user()
+        systemcontext = system()
+        assistantcontext = assistant()
+    return (usercontext, systemcontext, assistantcontext)
 
 
 class Program:
@@ -27,22 +40,47 @@ class Program:
             self.usercontext,
             self.systemcontext,
             self.assistantcontext,
-        ) = self._get_contexts(self.model)
+        ) = get_contexts(self.model)
         return self.__call__(self, **kwargs)
 
     def __call__(self, *args, **kwargs):
         pass
 
-    def __str__(self):
+    def to_string(self) -> str:
         return inspect.getsource(self.__call__)
 
-    @staticmethod
-    def _get_contexts(model: Model):
-        usercontext = nullcontext()
-        systemcontext = nullcontext()
-        assistantcontext = nullcontext()
-        if isinstance(model, Chat):
-            usercontext = user()
-            systemcontext = system()
-            assistantcontext = assistant()
-        return (usercontext, systemcontext, assistantcontext)
+
+def program_to_str(program: Program):
+    """Create a string representation of a program.
+    It is slightly tricky, since in addition to getting the code content, we need to
+        1) identify all global variables referenced within a function, and then
+        2) evaluate the variable value
+    This is required, since if we have some global constant `PROMPT` called,
+    we don't want to fetch from a previously created cache if the value of `PROMPT` changes.
+
+    To avoid extreme messiness, we don't traverse into globals pointing at functions.
+
+    Example:
+        >>> PROMPT = "Here is my question: {question}"
+        >>> class CorrectionProgram(Program):
+        >>>     def __call__(self, question: str, **kwargs):
+        >>>         return self.model + PROMPT.format(question)
+
+    Some helpful refs:
+        - https://github.com/universe-proton/universe-topology/issues/15
+    """
+    call_content = textwrap.dedent(inspect.getsource(program.__call__))
+    root = ast.parse(call_content)
+    root_names = {node.id for node in ast.walk(root) if isinstance(node, ast.Name)}
+    co_varnames = set(program.__call__.__code__.co_varnames)
+    names_to_resolve = sorted(root_names.difference(co_varnames))
+    resolved_names = ""
+    if len(names_to_resolve) > 0:
+        globals_as_dict = dict(inspect.getmembers(program.__call__))["__globals__"]
+        for name in names_to_resolve:
+            if name in globals_as_dict:
+                val = globals_as_dict[name]
+                # Ignore functions
+                if not callable(val):
+                    resolved_names += f"{val}\n"
+    return f"{call_content}{resolved_names}"

--- a/blendsql/_program.py
+++ b/blendsql/_program.py
@@ -46,9 +46,6 @@ class Program:
     def __call__(self, *args, **kwargs):
         pass
 
-    def to_string(self) -> str:
-        return inspect.getsource(self.__call__)
-
 
 def program_to_str(program: Program):
     """Create a string representation of a program.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,139 @@
+import uuid
+from dataclasses import dataclass
+from blendsql.models import Model
+from blendsql._program import Program
+
+TEST_QUESTION = "The quick brown fox jumps over the lazy dog"
+
+MODEL_A = "a"
+MODEL_B = "b"
+
+
+@dataclass
+class DummyModelOutput:
+    _variables: dict
+
+
+class DummyModel(Model):
+    def __init__(self, model_name_or_path: str, **kwargs):
+        super().__init__(
+            model_name_or_path=model_name_or_path,
+            requires_config=False,
+            tokenizer=None,
+            **kwargs,
+        )
+
+    def _load_model(self):
+        return self.model_name_or_path
+
+
+class DummyProgram(Program):
+    def __new__(
+        self,
+        **kwargs,
+    ):
+        return self.__call__(self, **kwargs)
+
+    def __call__(self, question: str, **kwargs):
+        return DummyModelOutput({"uuid": str(uuid.uuid4())})
+
+
+class DifferentDummyProgram(Program):
+    def __new__(
+        self,
+        **kwargs,
+    ):
+        return self.__call__(self, **kwargs)
+
+    def __call__(self, question: str, unused: str = None, **kwargs):
+        return DummyModelOutput({"uuid": str(uuid.uuid4())})
+
+
+class DummyProgramWithGlobal(Program):
+    def __new__(
+        self,
+        **kwargs,
+    ):
+        return self.__call__(self, **kwargs)
+
+    def __call__(self, question: str, **kwargs):
+        print(TEST_GLOBAL)
+        return DummyModelOutput({"uuid": str(uuid.uuid4())})
+
+
+def test_simple_cache():
+    a = DummyModel(MODEL_A).predict(program=DummyProgram, question=TEST_QUESTION)[
+        "uuid"
+    ]
+
+    b = DummyModel(MODEL_A).predict(program=DummyProgram, question=TEST_QUESTION)[
+        "uuid"
+    ]
+
+    assert a == b
+
+
+def test_different_models():
+    a = DummyModel(MODEL_A).predict(program=DummyProgram, question=TEST_QUESTION)[
+        "uuid"
+    ]
+
+    b = DummyModel(MODEL_B).predict(program=DummyProgram, question=TEST_QUESTION)[
+        "uuid"
+    ]
+
+    assert a != b
+
+
+def test_different_arguments():
+    a = DummyModel(MODEL_A).predict(program=DummyProgram, question=TEST_QUESTION)[
+        "uuid"
+    ]
+
+    b = DummyModel(MODEL_A).predict(
+        program=DummyProgram, question="This is a different question"
+    )["uuid"]
+
+    assert a != b
+
+
+def test_different_programs():
+    a = DummyModel(MODEL_A).predict(program=DummyProgram, question=TEST_QUESTION)[
+        "uuid"
+    ]
+
+    b = DummyModel(MODEL_A).predict(
+        program=DifferentDummyProgram, question=TEST_QUESTION
+    )["uuid"]
+
+    assert a != b
+
+
+def test_same_global_vars():
+    global TEST_GLOBAL
+    TEST_GLOBAL = "This is the same value"
+    a = DummyModel(MODEL_A).predict(
+        program=DummyProgramWithGlobal, question=TEST_QUESTION
+    )["uuid"]
+
+    TEST_GLOBAL = "This is the same value"
+    b = DummyModel(MODEL_A).predict(
+        program=DummyProgramWithGlobal, question=TEST_QUESTION
+    )["uuid"]
+
+    assert a == b
+
+
+def test_different_global_vars():
+    global TEST_GLOBAL
+    TEST_GLOBAL = "This is one value"
+    a = DummyModel(MODEL_A).predict(
+        program=DummyProgramWithGlobal, question=TEST_QUESTION
+    )["uuid"]
+
+    TEST_GLOBAL = "This is a different value"
+    b = DummyModel(MODEL_A).predict(
+        program=DummyProgramWithGlobal, question=TEST_QUESTION
+    )["uuid"]
+
+    assert a != b


### PR DESCRIPTION
This PR fixes some bugs/edge cases with the implementation of the `diskcache` cache for model predictions.

- `program_to_str()` updated, tracks global variables via `ast` to avoid unintended retrievals from cache
- `caching: bool` argument added to `Model` class
    - Allows user to toggle caching behavior off
- Caching test cases added

Closes #8 