### PR TITLE
Feature/lazy evaluation

### DIFF
--- a/blendsql/_sqlglot.py
+++ b/blendsql/_sqlglot.py
@@ -33,14 +33,6 @@ sqlglot.optimizer.simplify looks interesting
 """
 
 SUBQUERY_EXP = (exp.Select,)
-CONDITIONS = (
-    exp.Where,
-    exp.Group,
-    # IMPORTANT: If we uncomment limit, then `test_limit` in `test_single_table_blendsql.py` will not pass
-    # exp.Limit,
-    exp.Except,
-    exp.Order,
-)
 MODIFIERS = (
     exp.Delete,
     exp.AlterColumn,

--- a/blendsql/blend.py
+++ b/blendsql/blend.py
@@ -237,6 +237,12 @@ def preprocess_blendsql(query: str, default_model: Model) -> Tuple[str, dict, se
             # maybe if I was better at pp.Suppress we wouldn't need this
             kwargs_dict = {x[0]: x[-1] for x in parsed_results_dict["kwargs"]}
             kwargs_dict[IngredientKwarg.MODEL] = default_model
+            # Heuristic check to see if we should snag the singleton arg as context
+            if (
+                len(parsed_results_dict["args"]) == 1
+                and "::" in parsed_results_dict["args"][0]
+            ):
+                kwargs_dict[IngredientKwarg.CONTEXT] = parsed_results_dict["args"].pop()
             context_arg = kwargs_dict.get(
                 IngredientKwarg.CONTEXT,
                 (
@@ -622,12 +628,7 @@ def _blend(
 
             if table_to_title is not None:
                 kwargs_dict["table_to_title"] = table_to_title
-            # Heuristic check to see if we should snag the singleton arg as context
-            if (
-                len(parsed_results_dict["args"]) == 1
-                and "::" in parsed_results_dict["args"][0]
-            ):
-                kwargs_dict[IngredientKwarg.CONTEXT] = parsed_results_dict["args"].pop()
+
             # Optionally, recursively call blend() again to get subtable from args
             # This applies to `context` and `options`
             for i, unpack_kwarg in enumerate(

--- a/tests/test_multi_table_blendsql.py
+++ b/tests/test_multi_table_blendsql.py
@@ -90,7 +90,7 @@ def test_join_multi_exec(db, ingredients):
         LEFT JOIN constituents ON account_history.Symbol = constituents.Symbol
         WHERE constituents.Sector = 'Information Technology'
         AND {{starts_with('A', 'constituents::Name')}} = 1
-        AND lower(account_history.Action) like '%dividend%'
+        AND lower(LOWER(account_history.Action)) like '%dividend%'
         ORDER BY "Total Dividend Payout ($$)"
         """
     sql = """
@@ -99,7 +99,7 @@ def test_join_multi_exec(db, ingredients):
         LEFT JOIN constituents ON account_history.Symbol = constituents.Symbol
         WHERE constituents.Sector = 'Information Technology'
         AND constituents.Name LIKE 'A%'
-        AND lower(account_history.Action) like '%dividend%'
+        AND lower(LOWER(account_history.Action)) like '%dividend%'
         ORDER BY "Total Dividend Payout ($$)"
     """
     smoothie = blend(
@@ -165,7 +165,7 @@ def test_select_multi_exec(db, ingredients):
         FROM account_history
         LEFT JOIN constituents ON account_history.Symbol = constituents.Symbol
         WHERE constituents.Sector = {{select_first_sorted(options='constituents::Sector')}}
-        AND lower(account_history.Action) like '%dividend%'
+        AND lower(LOWER(account_history.Action)) like '%dividend%'
     """
     sql = """
     SELECT "Run Date", Account, Action, ROUND("Amount ($)", 2) AS 'Total Dividend Payout ($$)', Name
@@ -175,7 +175,7 @@ def test_select_multi_exec(db, ingredients):
             SELECT Sector FROM constituents
             ORDER BY Sector LIMIT 1
         )
-        AND lower(account_history.Action) like '%dividend%'
+        AND lower(LOWER(account_history.Action)) like '%dividend%'
     """
     smoothie = blend(
         query=blendsql,
@@ -457,13 +457,13 @@ def test_ingredient_in_select_with_join_multi_exec(db, ingredients):
     blendsql = """
     SELECT {{get_length('n_length', 'constituents::Name')}}
         FROM constituents JOIN account_history ON account_history.Symbol = constituents.Symbol
-        WHERE account_history.Action like '%dividend%'
+        WHERE LOWER(account_history.Action) like '%dividend%'
         ORDER BY constituents.Name
     """
     sql = """
     SELECT LENGTH(constituents.Name)
         FROM constituents JOIN account_history ON account_history.Symbol = constituents.Symbol
-        WHERE account_history.Action like '%dividend%'
+        WHERE LOWER(account_history.Action) like '%dividend%'
         ORDER BY constituents.Name
     """
     smoothie = blend(
@@ -478,7 +478,7 @@ def test_ingredient_in_select_with_join_multi_exec(db, ingredients):
         """
     SELECT COUNT(DISTINCT constituents.Name)
     FROM constituents JOIN account_history ON account_history.Symbol = constituents.Symbol
-    WHERE account_history.Action like '%dividend%'
+    WHERE LOWER(account_history.Action) like '%dividend%'
     """
     )[0]
     assert smoothie.meta.num_values_passed == passed_to_ingredient
@@ -493,12 +493,12 @@ def test_ingredient_in_select_with_join_multi_select_multi_exec(db, ingredients)
     blendsql = """
     SELECT {{get_length('n_length', 'constituents::Name')}}, Action
         FROM constituents JOIN account_history ON account_history.Symbol = constituents.Symbol
-        WHERE Action like '%dividend%'
+        WHERE LOWER(Action) like '%dividend%'
     """
     sql = """
     SELECT LENGTH(constituents.Name), Action
         FROM constituents JOIN account_history ON account_history.Symbol = constituents.Symbol
-        WHERE Action like '%dividend%'
+        WHERE LOWER(Action) like '%dividend%'
     """
     smoothie = blend(
         query=blendsql,
@@ -512,7 +512,7 @@ def test_ingredient_in_select_with_join_multi_select_multi_exec(db, ingredients)
         """
     SELECT COUNT(DISTINCT constituents.Name)
     FROM constituents JOIN account_history ON account_history.Symbol = constituents.Symbol
-    WHERE account_history.Action like '%dividend%'
+    WHERE LOWER(account_history.Action) like '%dividend%'
     """
     )[0]
     assert smoothie.meta.num_values_passed == passed_to_ingredient

--- a/tests/test_single_table_blendsql.py
+++ b/tests/test_single_table_blendsql.py
@@ -592,7 +592,10 @@ def test_apply_limit_with_predicate(db, ingredients):
         """
     SELECT COUNT(DISTINCT merchant) FROM transactions WHERE amount > 1300 LIMIT 3    """
     )[0]
-    assert smoothie.meta.num_values_passed == passed_to_ingredient
+    # We say `<=` here because the ingredient operates over sets, rather than lists
+    # So this kind of screws up the `LIMIT` calculation
+    # But execution outputs should be the same (tested above)
+    assert smoothie.meta.num_values_passed <= passed_to_ingredient
 
 
 if __name__ == "__main__":

--- a/tests/test_single_table_blendsql.py
+++ b/tests/test_single_table_blendsql.py
@@ -551,5 +551,19 @@ def test_query_options_arg(db, ingredients):
     assert smoothie.df.values.flat[0] == "Paypal"
 
 
+@pytest.mark.parametrize("db", databases)
+def test_apply_limit(db, ingredients):
+    # commit 335c67a
+    blendsql = """
+    SELECT {{get_length('length', 'transactions::merchant')}} FROM transactions ORDER BY merchant LIMIT 1
+    """
+    smoothie = blend(
+        query=blendsql,
+        db=db,
+        ingredients=ingredients,
+    )
+    assert smoothie.meta.num_values_passed == 1
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
On queries like `benchmarks/national_parks/q05.sql`:

```sql
SELECT {{ImageCaption('parks::Image')}} as "Image Description" FROM parks LIMIT 1
```

We apply the `LIMIT` clause (and any other surrounding filters) prior to calling the `ImageCaption` ingredient

## Benchmark Results:
Before:
| Task           |   Average Runtime |   # Unique Queries |
|:---------------|------------------:|-------------------:|
| financials     |         0.0402491 |                  7 |
| rugby          |         0.323255  |                  4 |
| national_parks |         2.07314   |                  5 |
| 1966_nba_draft |         0.119926  |                  2 |

After:
| Task           |   Average Runtime |   # Unique Queries |
|:---------------|------------------:|-------------------:|
| financials     |          0.040797 |                  7 |
| rugby          |          0.319473 |                  4 |
| national_parks |          0.865904 |                  5 |
| 1966_nba_draft |          0.115434 |                  2 |