### PR TITLE
`unpack_options()`, adding options argument to MapIngredient

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ SELECT COUNT(*) FROM parks
 |       1 |
 <hr>
 
+_What's the difference in visitors for those parks with a superlative in their description vs. those without?_
+```sql
+SELECT SUM(CAST(REPLACE("Recreation Visitors (2022)", ',', '') AS integer)) AS "Total Visitors", 
+{{LLMMap('Contains a superlative?', 'parks::Description', options='t;f')}} AS "Description Contains Superlative",
+GROUP_CONCAT(Name, ', ') AS "Park Names"
+FROM parks
+GROUP BY "Description Contains Superlative"
+```
+| Total Visitors |   Description Contains Superlative | Park Names                    |
+|---------------:|-----------------------------------:|:------------------------------|
+|          43365 |                                  0 | Everglades, Katmai            |
+|        2722385 |                                  1 | Death Valley, New River Gorge |
+<hr>
+
 Now, we have an intermediate representation for our LLM to use that is explainable, debuggable, and [very effective at hybrid question-answering tasks](https://arxiv.org/abs/2402.17882).
 
 For in-depth descriptions of the above queries, check out our [documentation](https://parkervg.github.io/blendsql/).

--- a/blendsql/_constants.py
+++ b/blendsql/_constants.py
@@ -27,4 +27,5 @@ class IngredientKwarg:
     CONTEXT: str = "context"
     VALUES: str = "values"
     OPTIONS: str = "options"
+    REGEX: str = "regex"
     MODEL: str = "model"

--- a/blendsql/_smoothie.py
+++ b/blendsql/_smoothie.py
@@ -35,3 +35,16 @@ class Smoothie:
 
     def __post_init__(self):
         self.df = PrettyDataFrame(self.df)
+
+    def summary(self):
+        return tabulate(
+            pd.DataFrame(
+                {
+                    "Time (s)": self.meta.process_time_seconds,
+                    "Values Passed to Ingredients": self.meta.num_values_passed,
+                    "Prompt Tokens": self.meta.prompt_tokens,
+                    "Completion Tokens": self.meta.completion_tokens,
+                },
+                index=[0],
+            )
+        )

--- a/blendsql/_smoothie.py
+++ b/blendsql/_smoothie.py
@@ -37,7 +37,9 @@ class Smoothie:
         self.df = PrettyDataFrame(self.df)
 
     def summary(self):
-        return tabulate(
+        s = "---------------- SUMMARY ----------------\n"
+        s += self.meta.query + "\n"
+        s += tabulate(
             pd.DataFrame(
                 {
                     "Time (s)": self.meta.process_time_seconds,
@@ -48,3 +50,4 @@ class Smoothie:
                 index=[0],
             )
         )
+        return s

--- a/blendsql/db/_sqlalchemy.py
+++ b/blendsql/db/_sqlalchemy.py
@@ -125,7 +125,7 @@ class SQLAlchemyDatabase(Database):
         create_table_stmt = re.sub(
             r"^CREATE TABLE", "CREATE TEMP TABLE", create_table_stmt
         )
-        logger.debug(Fore.CYAN + create_table_stmt + Fore.RESET)
+        logger.debug(Fore.LIGHTBLACK_EX + create_table_stmt + Fore.RESET)
         self.con.execute(text(create_table_stmt))
         df.to_sql(name=tablename, con=self.con, if_exists="append", index=False)
 

--- a/blendsql/generate/regex.py
+++ b/blendsql/generate/regex.py
@@ -9,11 +9,11 @@ from ..models import Model, OllamaLLM
 def regex(
     model: Model,
     prompt: str,
-    pattern: str,
+    regex: str,
     max_tokens: Optional[int] = None,
     stop_at: Optional[Union[List[str], str]] = None,
 ) -> str:
-    generator = outlines.generate.regex(model.model_obj, regex_str=pattern)
+    generator = outlines.generate.regex(model.model_obj, regex_str=regex)
     return generator(prompt, max_tokens=max_tokens, stop_at=stop_at)
 
 

--- a/blendsql/ingredients/builtin/join/main.py
+++ b/blendsql/ingredients/builtin/join/main.py
@@ -92,7 +92,7 @@ class JoinProgram(Program):
             response = generate.regex(
                 model,
                 prompt=prompt,
-                pattern=regex(len(left_values)),
+                regex=regex(len(left_values)),
                 max_tokens=max_tokens,
                 stop_at=["---"],
             )

--- a/blendsql/ingredients/builtin/map/main.py
+++ b/blendsql/ingredients/builtin/map/main.py
@@ -117,7 +117,7 @@ class MapProgram(Program):
             prompt += f"\nHere are some example outputs: {example_outputs}\n"
         prompt += "\nA:"
         if isinstance(model, LocalModel) and regex is not None:
-            response = generate.regex(model, prompt=prompt, pattern=regex(len(values)))
+            response = generate.regex(model, prompt=prompt, regex=regex(len(values)))
         else:
             response = generate.text(
                 model, prompt=prompt, max_tokens=max_tokens, stop_at="\n"
@@ -139,7 +139,7 @@ class LLMMap(MapIngredient):
         value_limit: Union[int, None] = None,
         example_outputs: Optional[str] = None,
         output_type: Optional[str] = None,
-        pattern: Optional[str] = None,
+        regex: Optional[str] = None,
         table_to_title: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> Iterable[Any]:
@@ -152,7 +152,7 @@ class LLMMap(MapIngredient):
             value_limit: Optional limit on the number of values to pass to the Model
             example_outputs: If binary == False, this gives the Model an example of the output we expect.
             output_type: One of 'numeric', 'string', 'bool'
-            pattern: Optional regex to constrain answer generation.
+            regex: Optional regex to constrain answer generation.
             table_to_title: Mapping from tablename to a title providing some more context.
 
         Returns:
@@ -165,7 +165,7 @@ class LLMMap(MapIngredient):
         # Unpack default kwargs
         tablename, colname = self.unpack_default_kwargs(**kwargs)
         # Remote endpoints can't use patterns
-        pattern = None if isinstance(model, RemoteModel) else pattern
+        regex = None if isinstance(model, RemoteModel) else regex
         if value_limit is not None:
             values = values[:value_limit]
         values = [value if not pd.isna(value) else "-" for value in values]
@@ -207,7 +207,7 @@ class LLMMap(MapIngredient):
                 output_type=output_type,
                 include_tf_disclaimer=include_tf_disclaimer,
                 table_title=table_title,
-                regex=pattern,
+                regex=regex,
                 max_tokens=max_tokens,
                 **kwargs,
             )
@@ -259,7 +259,7 @@ class LLMMap(MapIngredient):
                 continue
         logger.debug(
             Fore.YELLOW
-            + f"Finished with values:\n{json.dumps(dict(zip(values[:10], split_results[:10])), indent=4)}"
+            + f"Finished LLMMap with values:\n{json.dumps(dict(zip(values[:10], split_results[:10])), indent=4)}"
             + Fore.RESET
         )
         return split_results

--- a/blendsql/ingredients/ingredient.py
+++ b/blendsql/ingredients/ingredient.py
@@ -172,7 +172,7 @@ class MapIngredient(Ingredient):
             original_table[new_arg_column] = None
             return (new_arg_column, tablename, colname, original_table)
 
-        if options:
+        if options is not None:
             # Override any pattern with our new unpacked options
             unpacked_options = unpack_options(
                 options=options, aliases_to_tablenames=aliases_to_tablenames, db=self.db
@@ -408,12 +408,14 @@ class QAIngredient(Ingredient):
             if subtable.empty:
                 raise IngredientException("Empty subtable passed to QAIngredient!")
 
-        unpacked_options = unpack_options(
-            options=options, aliases_to_tablenames=aliases_to_tablenames, db=self.db
-        )
+        if options is not None:
+            kwargs[IngredientKwarg.OPTIONS] = unpack_options(
+                options=options, aliases_to_tablenames=aliases_to_tablenames, db=self.db
+            )
+        else:
+            kwargs[IngredientKwarg.OPTIONS] = None
 
         self.num_values_passed += len(subtable) if subtable is not None else 0
-        kwargs[IngredientKwarg.OPTIONS] = unpacked_options
         kwargs[IngredientKwarg.CONTEXT] = subtable
         kwargs[IngredientKwarg.QUESTION] = question
         response: Union[str, int, float] = self._run(*args, **kwargs)

--- a/blendsql/ingredients/ingredient.py
+++ b/blendsql/ingredients/ingredient.py
@@ -1,10 +1,11 @@
+import re
 from attr import attrs, attrib
 from abc import abstractmethod
 import pandas as pd
 from sqlglot import exp
 import json
 from skrub import Joiner
-from typing import Any, Union, Dict, Tuple, Callable, Set, Optional, List, Type
+from typing import Any, Union, Dict, Tuple, Callable, Set, Optional, Type
 from collections.abc import Collection, Iterable
 import uuid
 from colorama import Fore
@@ -14,10 +15,16 @@ from functools import partialmethod
 from .._exceptions import IngredientException
 from .._logger import logger
 from .. import utils
-from .._constants import IngredientKwarg, IngredientType
+from .._constants import (
+    IngredientKwarg,
+    IngredientType,
+    DEFAULT_ANS_SEP,
+    DEFAULT_NAN_ANS,
+)
 from ..db import Database
 from ..db.utils import select_all_from_table_query
 from ..models import Model
+from .utils import unpack_options
 
 
 def unpack_default_kwargs(**kwargs):
@@ -94,7 +101,13 @@ class MapIngredient(Ingredient):
         return unpack_default_kwargs(**kwargs)
 
     def __call__(
-        self, question: str = None, context: str = None, *args, **kwargs
+        self,
+        question: str = None,
+        context: str = None,
+        regex: Optional[Callable] = None,
+        options: Optional[Union[list, str]] = None,
+        *args,
+        **kwargs,
     ) -> tuple:
         """Returns tuple with format (arg, tablename, colname, new_table)"""
         # Unpack kwargs
@@ -159,8 +172,18 @@ class MapIngredient(Ingredient):
             original_table[new_arg_column] = None
             return (new_arg_column, tablename, colname, original_table)
 
+        if options:
+            # Override any pattern with our new unpacked options
+            unpacked_options = unpack_options(
+                options=options, aliases_to_tablenames=aliases_to_tablenames, db=self.db
+            )
+            base_regex = f"(({'|'.join([re.escape(option) for option in unpacked_options])}|{DEFAULT_NAN_ANS}){DEFAULT_ANS_SEP})"
+            kwargs[IngredientKwarg.REGEX] = (
+                lambda num_repeats: base_regex + "{" + str(num_repeats) + "}"
+            )
+        else:
+            kwargs[IngredientKwarg.REGEX] = regex
         kwargs[IngredientKwarg.VALUES] = values
-        kwargs["original_table"] = original_table
         kwargs[IngredientKwarg.QUESTION] = question
         mapped_values: Collection[Any] = self._run(*args, **kwargs)
         self.num_values_passed += len(mapped_values)
@@ -385,27 +408,10 @@ class QAIngredient(Ingredient):
             if subtable.empty:
                 raise IngredientException("Empty subtable passed to QAIngredient!")
 
-        unpacked_options: Union[List[str], None] = options
-        if options is not None:
-            if not isinstance(options, list):
-                try:
-                    tablename, colname = utils.get_tablename_colname(options)
-                    tablename = aliases_to_tablenames.get(tablename, tablename)
-                    # Optionally materialize a CTE
-                    if tablename in self.db.lazy_tables:
-                        unpacked_options = (
-                            self.db.lazy_tables.pop(tablename)
-                            .collect()[colname]
-                            .unique()
-                            .tolist()
-                        )
-                    else:
-                        unpacked_options = self.db.execute_to_list(
-                            f'SELECT DISTINCT "{colname}" FROM "{tablename}"'
-                        )
-                except ValueError:
-                    unpacked_options = options.split(";")
-            unpacked_options: Set[str] = set(unpacked_options)
+        unpacked_options = unpack_options(
+            options=options, aliases_to_tablenames=aliases_to_tablenames, db=self.db
+        )
+
         self.num_values_passed += len(subtable) if subtable is not None else 0
         kwargs[IngredientKwarg.OPTIONS] = unpacked_options
         kwargs[IngredientKwarg.CONTEXT] = subtable

--- a/blendsql/ingredients/utils.py
+++ b/blendsql/ingredients/utils.py
@@ -5,27 +5,22 @@ from ..db import Database
 
 
 def unpack_options(
-    options: Union[List[str], None], aliases_to_tablenames: Dict[str, str], db: Database
-):
-    unpacked_options: Union[List[str], None] = options
-    if options is not None:
-        if not isinstance(options, list):
-            try:
-                tablename, colname = get_tablename_colname(options)
-                tablename = aliases_to_tablenames.get(tablename, tablename)
-                # Optionally materialize a CTE
-                if tablename in db.lazy_tables:
-                    unpacked_options = (
-                        db.lazy_tables.pop(tablename)
-                        .collect()[colname]
-                        .unique()
-                        .tolist()
-                    )
-                else:
-                    unpacked_options = db.execute_to_list(
-                        f'SELECT DISTINCT "{colname}" FROM "{tablename}"'
-                    )
-            except ValueError:
-                unpacked_options = options.split(";")
-        unpacked_options: Set[str] = set(unpacked_options)
-    return unpacked_options
+    options: Union[List[str], str], aliases_to_tablenames: Dict[str, str], db: Database
+) -> Set[str]:
+    unpacked_options = options
+    if not isinstance(options, list):
+        try:
+            tablename, colname = get_tablename_colname(options)
+            tablename = aliases_to_tablenames.get(tablename, tablename)
+            # Optionally materialize a CTE
+            if tablename in db.lazy_tables:
+                unpacked_options = (
+                    db.lazy_tables.pop(tablename).collect()[colname].unique().tolist()
+                )
+            else:
+                unpacked_options = db.execute_to_list(
+                    f'SELECT DISTINCT "{colname}" FROM "{tablename}"'
+                )
+        except ValueError:
+            unpacked_options = options.split(";")
+    return set(unpacked_options)

--- a/blendsql/ingredients/utils.py
+++ b/blendsql/ingredients/utils.py
@@ -1,0 +1,31 @@
+from typing import Union, List, Set, Dict
+
+from ..utils import get_tablename_colname
+from ..db import Database
+
+
+def unpack_options(
+    options: Union[List[str], None], aliases_to_tablenames: Dict[str, str], db: Database
+):
+    unpacked_options: Union[List[str], None] = options
+    if options is not None:
+        if not isinstance(options, list):
+            try:
+                tablename, colname = get_tablename_colname(options)
+                tablename = aliases_to_tablenames.get(tablename, tablename)
+                # Optionally materialize a CTE
+                if tablename in db.lazy_tables:
+                    unpacked_options = (
+                        db.lazy_tables.pop(tablename)
+                        .collect()[colname]
+                        .unique()
+                        .tolist()
+                    )
+                else:
+                    unpacked_options = db.execute_to_list(
+                        f'SELECT DISTINCT "{colname}" FROM "{tablename}"'
+                    )
+            except ValueError:
+                unpacked_options = options.split(";")
+        unpacked_options: Set[str] = set(unpacked_options)
+    return unpacked_options

--- a/blendsql/models/_model.py
+++ b/blendsql/models/_model.py
@@ -111,7 +111,7 @@ class Model:
             # First, check our cache
             key: str = self._create_key(program, **kwargs)
             if key in self.cache:
-                logger.debug(Fore.MAGENTA + "Using cache..." + Fore.RESET)
+                logger.debug(Fore.MAGENTA + "Using model cache..." + Fore.RESET)
                 response: str = self.cache.get(key)  # type: ignore
                 self.prompts.insert(-1, self.format_prompt(response, **kwargs))
                 return response

--- a/blendsql/parse/_checks.py
+++ b/blendsql/parse/_checks.py
@@ -1,11 +1,12 @@
 # This file contains sqlglot-based functions that return a boolean
 from sqlglot import exp
+from functools import lru_cache
 
 from ._constants import SUBQUERY_EXP
 from ._utils import get_first_child
 
 
-def all_terminals_are_true(node) -> bool:
+def all_terminals_are_true(node: exp.Expression) -> bool:
     """Check to see if all terminal nodes of a given node are TRUE booleans."""
     for n, _, _ in node.walk():
         try:
@@ -16,7 +17,7 @@ def all_terminals_are_true(node) -> bool:
     return True
 
 
-def ingredients_only_in_top_select(node) -> bool:
+def ingredients_only_in_top_select(node: exp.Expression) -> bool:
     select_exps = list(node.find_all(exp.Select))
     if len(select_exps) == 1:
         # Check if the only `STRUCT` nodes are found in select
@@ -33,17 +34,59 @@ def ingredients_only_in_top_select(node) -> bool:
     return False
 
 
-def in_subquery(node) -> bool:
+def in_subquery(node: exp.Expression) -> bool:
     _ancestor = node.find_ancestor(SUBQUERY_EXP)
     if _ancestor is not None:
         return _ancestor.find_ancestor(SUBQUERY_EXP) is not None
     return False
 
 
-def in_cte(node, return_name: bool = False):
+def in_cte(node: exp.Expression, return_name: bool = False):
     p = node.parent
     if p is not None:
         table_alias = p.find(exp.TableAlias)
         if table_alias is not None:
             return (True, table_alias.name) if return_name else True
     return (False, None) if return_name else False
+
+
+def contains_ingredient(node: exp.Expression) -> bool:
+    num_structs = len(list(node.find_all(exp.Struct)))
+    return num_structs > 0 and (len(list(node.find_all(exp.Struct))) % 2) == 0
+
+
+def ingredient_alias_in_query_body(node: exp.Expression) -> bool:
+    """Check if an alias created from an ingredient is used in the main query body.
+
+    Examples:
+        ```sql
+        SELECT Name,
+        {{LLMMap('Contains a superlative?', 'parks::Description')}} AS "Contains Superlative"
+        FROM parks
+        GROUP BY "Contains Superlative"
+        ```
+        Returns `True`
+
+        ```sql
+        SELECT Name,
+        {{LLMMap('Contains a superlative?', 'parks::Description')}} AS "Contains Superlative"
+        FROM parks
+        ```
+        Returns `False`
+    """
+    # TODO: is there a way to return false if generator is empty
+
+    @lru_cache
+    def get_referenced_columns(node: exp.Expression) -> set:
+        """Returns set of all referenced columns in body of query
+        (i.e. not in select statement)
+        """
+        return set([i.name for i in node.find_all(exp.Column)])
+
+    for n in node.find_all(exp.Alias):
+        ref_columns = get_referenced_columns(node)
+        if contains_ingredient(n):
+            if n.alias in ref_columns:
+                return True
+
+    return False

--- a/blendsql/parse/_parse.py
+++ b/blendsql/parse/_parse.py
@@ -18,7 +18,7 @@ from sqlglot.optimizer.scope import find_all_in_scope
 from attr import attrs, attrib
 
 from ..utils import recover_blendsql
-from .._constants import DEFAULT_ANS_SEP, DEFAULT_NAN_ANS
+from .._constants import DEFAULT_ANS_SEP, DEFAULT_NAN_ANS, IngredientKwarg
 from ._dialect import _parse_one, FTS5SQLite
 from . import _checks as check
 from . import _transforms as transform
@@ -381,31 +381,31 @@ class SubqueryContextManager:
                 - output_type
                     - 'boolean' | 'integer' | 'float' | 'string'
 
-                - pattern: regular expression pattern lambda to use in constrained decoding with Model
-                    - See `create_pattern` for more info on these pattern lambdas
+                - regex: regular expression pattern lambda to use in constrained decoding with Model
+                    - See `create_regex` for more info on these regex lambdas
 
                 - options: Optional str default to pass to `options` argument in a QAIngredient
                     - Will have the form '{table}::{column}'
         """
 
-        def create_pattern(
+        def create_regex(
             output_type: Literal["boolean", "integer", "float"]
         ) -> Callable[[int], str]:
-            """Helper function to create a pattern lambda.
-            These pattern lambdas take an integer (num_repeats) and return
-            a regex pattern which is restricted to repeat exclusively num_repeats times.
+            """Helper function to create a regex lambda.
+            These regex lambdas take an integer (num_repeats) and return
+            a regex regex which is restricted to repeat exclusively num_repeats times.
             """
             if output_type == "boolean":
-                base_pattern = f"((t|f|{DEFAULT_NAN_ANS}){DEFAULT_ANS_SEP})"
+                base_regex = f"((t|f|{DEFAULT_NAN_ANS}){DEFAULT_ANS_SEP})"
             elif output_type == "integer":
                 # SQLite max is 18446744073709551615
                 # This is 20 digits long, so to be safe, cap the generation at 19
-                base_pattern = r"((\d{1,18}" + f"|{DEFAULT_NAN_ANS}){DEFAULT_ANS_SEP})"
+                base_regex = r"((\d{1,18}" + f"|{DEFAULT_NAN_ANS}){DEFAULT_ANS_SEP})"
             elif output_type == "float":
-                base_pattern = r"(((\d|\.)+" + f"|{DEFAULT_NAN_ANS}){DEFAULT_ANS_SEP})"
+                base_regex = r"(((\d|\.)+" + f"|{DEFAULT_NAN_ANS}){DEFAULT_ANS_SEP})"
             else:
                 raise ValueError(f"Unknown output_type {output_type}")
-            return lambda num_repeats: base_pattern + "{" + str(num_repeats) + "}"
+            return lambda num_repeats: base_regex + "{" + str(num_repeats) + "}"
 
         added_kwargs: Dict[str, Any] = {}
         ingredient_node = _parse_one(self.sql()[start:end])
@@ -461,10 +461,10 @@ class SubqueryContextManager:
         elif isinstance(
             ingredient_node_in_context.parent, (exp.Order, exp.Ordered, exp.AggFunc)
         ):
-            output_type = "float"  # Use 'float' as default numeric pattern, since it's more expressive than 'integer'
+            output_type = "float"  # Use 'float' as default numeric regex, since it's more expressive than 'integer'
         if output_type is not None:
             added_kwargs["output_type"] = output_type
-            added_kwargs["pattern"] = create_pattern(output_type)
+            added_kwargs[IngredientKwarg.REGEX] = create_regex(output_type)
         return added_kwargs
 
     def sql(self, dialect: sqlglot.dialects.Dialect = FTS5SQLite):

--- a/tests/test_single_table_blendsql.py
+++ b/tests/test_single_table_blendsql.py
@@ -647,5 +647,31 @@ def test_where_in_clause(db, ingredients):
     assert_equality(smoothie=smoothie, sql_df=sql_df)
 
 
+@pytest.mark.parametrize("db", databases)
+def test_group_by_with_ingredient_alias(db, ingredients):
+    """b28a129"""
+    blendsql = """
+    SELECT SUM(amount) AS "total amount", 
+    {{get_length('transactions::merchant')}} AS "Merchant Length"
+    FROM transactions
+    GROUP BY "Merchant Length"
+    ORDER BY "total amount"
+    """
+    sql = """
+    SELECT SUM(amount) AS "total amount", 
+    LENGTH(merchant) AS "Merchant Length"
+    FROM transactions
+    GROUP BY "Merchant Length"
+    ORDER BY "total amount"
+    """
+    smoothie = blend(
+        query=blendsql,
+        db=db,
+        ingredients=ingredients,
+    )
+    sql_df = db.execute_to_df(sql)
+    assert_equality(smoothie=smoothie, sql_df=sql_df)
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Enables the below query. For each value in the `Description` column, the LLM generates either a `t` or a `f`. This is achieved via the `unpack_options()` argument, which in the MapIngredient class, will construct a suitable regex  for the downstream `generate.regex`.

```sql
SELECT SUM(CAST(REPLACE("Recreation Visitors (2022)", ',', '') AS integer)) AS Visitors, 
{{LLMMap('Contains a superlative?', 'parks::Description', options='t;f')}} AS "Description Contains Superlative",
GROUP_CONCAT(Name, ', ') AS "Park Names"
FROM parks
GROUP BY "Description Contains Superlative"
```