### PR TITLE
Re-work `LLMJoin` pattern

### DIFF
--- a/benchmark/1966_nba_draft/queries/q02.sql
+++ b/benchmark/1966_nba_draft/queries/q02.sql
@@ -1,7 +1,7 @@
 SELECT title, player FROM w JOIN {{
     LLMJoin(
-        left_on='documents::title',
-        right_on='w::player'
+        'w::player',
+        'documents::title'
     )
 }} WHERE {{
     LLMMap(

--- a/benchmark/financials/queries/q07.sql
+++ b/benchmark/financials/queries/q07.sql
@@ -1,8 +1,8 @@
 SELECT w."Percent of Account" FROM (SELECT * FROM "portfolio" WHERE Quantity > 200 OR "Today''s Gain/Loss Percent" > 0.05) as w
 JOIN {{
     do_join(
-        left_on='geographic::Symbol',
-        right_on='w::Symbol'
+        'w::Symbol',
+        'geographic::Symbol'
     )
 }} WHERE {{starts_with('F', 'w::Symbol')}}
 AND w."Percent of Account" < 0.2

--- a/blendsql/ingredients/builtin/vqa/main.py
+++ b/blendsql/ingredients/builtin/vqa/main.py
@@ -19,6 +19,19 @@ class ImageCaption(MapIngredient):
     def from_args(cls, model: Model = None):
         return partialclass(cls, model=model)
 
+    def __call__(
+        self,
+        context: str = None,
+        *args,
+        **kwargs,
+    ) -> tuple:
+        """
+        This allows us to call this ingredient via `{{ImageCaption('table::col')}}`.
+        """
+        return super().__call__(
+            question=None, context=context, options=None, *args, **kwargs
+        )
+
     def run(self, model: Model, values: List[bytes], **kwargs):
         """Generates a caption for all byte images passed to it."""
         if model is None:

--- a/blendsql/ingredients/ingredient.py
+++ b/blendsql/ingredients/ingredient.py
@@ -319,9 +319,9 @@ class JoinIngredient(Ingredient):
 
     def __call__(
         self,
-        question: Optional[str] = None,
         left_on: Optional[str] = None,
         right_on: Optional[str] = None,
+        question: Optional[str] = None,
         *args,
         **kwargs,
     ) -> tuple:
@@ -449,9 +449,9 @@ class JoinIngredient(Ingredient):
         return (
             left_tablename,
             right_tablename,
-            f"""JOIN "{temp_join_tablename}" ON "{right_tablename}"."{right_colname}" = "{temp_join_tablename}".right
-               JOIN "{left_tablename}" ON "{left_tablename}"."{left_colname}" = "{temp_join_tablename}".left
-               """,
+            f"""JOIN "{temp_join_tablename}" ON "{left_tablename}"."{left_colname}" = "{temp_join_tablename}".left
+              JOIN "{right_tablename}" ON "{right_tablename}"."{right_colname}" = "{temp_join_tablename}".right
+              """,
             temp_join_tablename,
         )
 

--- a/blendsql/ingredients/ingredient.py
+++ b/blendsql/ingredients/ingredient.py
@@ -170,7 +170,6 @@ class MapIngredient(Ingredient):
         self,
         question: Optional[str] = None,
         context: Optional[str] = None,
-        # regex: Optional[Callable] = None,
         options: Optional[Union[list, str]] = None,
         *args,
         **kwargs,

--- a/docs/reference/ingredients/LLMJoin.md
+++ b/docs/reference/ingredients/LLMJoin.md
@@ -27,9 +27,9 @@ For example:
 SELECT Capitals.name, State.name FROM Capitals
     JOIN {{
         LLMJoin(
-            'Align state to capital', 
-            left_on='States::name', 
-            right_on='Capitals::name'
+            'Capitals::name',
+            'States::name',
+            question='Align state to capital.',
         )
     }}
 ```

--- a/examples/llmjoin.py
+++ b/examples/llmjoin.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from blendsql import BlendSQL
+from blendsql.ingredients import LLMJoin, LLMQA
+from blendsql.models import LiteLLM
+
+if __name__ == "__main__":
+    bsql = BlendSQL(
+        {
+            "fruit": pd.DataFrame(
+                {"name": ["apple", "orange", "apricot", "pear", "blueberry", "banana"]}
+            ),
+            "colors": pd.DataFrame(
+                {"name": ["orange", "blue", "yellow", "red", "yellow"]}
+            ),
+        },
+        ingredients={LLMJoin, LLMQA},
+        model=LiteLLM("openai/gpt-4o-mini", caching=False),
+        verbose=True,
+    )
+    smoothie = bsql.execute(
+        """
+        SELECT * FROM fruit
+        JOIN {{
+            LLMJoin(
+                'fruit::name',
+                'colors::name'
+            )
+        }}
+        """,
+    )

--- a/tests/models/test_models_rugby.py
+++ b/tests/models/test_models_rugby.py
@@ -55,8 +55,8 @@ def test_llmjoin(bsql, model, ingredients):
         SELECT date, rival, score, documents.content AS "Team Description" FROM w
           JOIN {{
               LLMJoin(
-                  left_on='documents::title',
-                  right_on='w::rival'
+                  'w::rival',
+                  'documents::title'
               )
           }} WHERE rival = 'nsw waratahs'
         """,

--- a/tests/test_multi_table_blendsql.py
+++ b/tests/test_multi_table_blendsql.py
@@ -247,8 +247,8 @@ def test_join_ingredient_multi_exec(bsql):
         SELECT Account, Quantity FROM returns
         JOIN {{
             do_join(
-                left_on='account_history::Account',
-                right_on='returns::Annualized Returns'
+                'returns::Annualized Returns',
+                'account_history::Account'
             )
         }}
         """
@@ -397,7 +397,7 @@ def test_cte_qa_multi_exec(bsql):
         """
        {{
             get_table_size(
-                (
+                context=(
                     WITH a AS (
                         SELECT * FROM (SELECT DISTINCT * FROM portfolio) as w
                             WHERE {{starts_with('F', 'w::Symbol')}} = TRUE
@@ -443,7 +443,7 @@ def test_cte_qa_named_multi_exec(bsql):
         """
        {{
             get_table_size(
-                (
+                context=(
                     WITH a AS (
                         SELECT * FROM (SELECT DISTINCT * FROM portfolio) as w
                             WHERE {{starts_with('F', 'w::Symbol')}} = TRUE
@@ -555,8 +555,8 @@ def test_subquery_alias_with_join_multi_exec(bsql):
         SELECT w."Percent of Account" FROM (SELECT * FROM "portfolio" WHERE Quantity > 200 OR "Today's Gain/Loss Percent" > 0.05) as w
         JOIN {{
             do_join(
-                left_on='geographic::Symbol',
-                right_on='w::Symbol'
+                'w::Symbol',
+                'geographic::Symbol'
             )
         }} WHERE {{starts_with('F', 'w::Symbol')}}
         AND w."Percent of Account" < 0.2
@@ -590,8 +590,8 @@ def test_subquery_alias_with_join_multi_exec_and(bsql):
         SELECT w."Percent of Account" FROM (SELECT * FROM "portfolio" WHERE Quantity > 200 OR "Today's Gain/Loss Percent" > 0.05) as w
         JOIN {{
             do_join(
-                left_on='geographic::Symbol',
-                right_on='w::Symbol'
+                'w::Symbol',
+                'geographic::Symbol'
             )
         }} AND {{starts_with('F', 'w::Symbol')}}
         """
@@ -699,8 +699,8 @@ def test_join_with_multiple_ingredients(bsql):
         SELECT "Run Date", Action, portfolio.Symbol FROM account_history
         JOIN {{
             do_join(
-                right_on='account_history::Symbol',
-                left_on='portfolio::Symbol'
+                'account_history::Symbol',
+                'portfolio::Symbol'
             )
         }} AND {{
             starts_with('H', 'portfolio::Description')

--- a/tests/test_single_table_blendsql.py
+++ b/tests/test_single_table_blendsql.py
@@ -608,7 +608,7 @@ def test_group_by_with_ingredient_alias(bsql):
     smoothie = bsql.execute(
         """
         SELECT SUM(amount) AS "total amount",
-        {{get_length('transactions::merchant')}} AS "Merchant Length"
+        {{get_length(context='transactions::merchant')}} AS "Merchant Length"
         FROM transactions
         GROUP BY "Merchant Length"
         ORDER BY "total amount"


### PR DESCRIPTION
Moving from the incorrect + verbose:

```sql
SELECT * FROM a 
JOIN {{
    LLMJoin(
        left_on='b',
        right_on='a'
    )
}}
```

to:

```sql
SELECT * FROM a 
JOIN {{
    LLMJoin(
        'a',
        'b'
    )
}}
```

Using `inspect.bind` in `blend.py` to bind ingredient args to their python function. 

```python
# Bind arguments to function
from inspect import signature

sig = signature(_ingredient)
bound = sig.bind(*parsed_results_dict["args"], **kwargs_dict)
kwargs_dict = {
    k: v for k, v in bound.arguments.items() if k != "kwargs"
} | bound.arguments["kwargs"]
```