### PR TITLE
Use DSPy for Unconstrained Prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,28 +334,27 @@ from blendsql import BlendSQL
 from blendsql.ingredients.builtin import LLMMap, DEFAULT_MAP_FEW_SHOT
 
 ingredients = {
-    LLMMap.from_args(
-        few_shot_examples=[
-            *DEFAULT_MAP_FEW_SHOT,
-            {
-                "question": "Is this a sport?",
-                "mapping": {
-                    "Soccer": True,
-                    "Chair": False,
-                    "Banana": False,
-                    "Golf": True
-                },
-                # Below are optional
-                "column_name": "Items",
-                "table_name": "Table",
-                "return_type": "boolean"
-            }
-        ],
-        # Will fetch `k` most relevant few-shot examples using embedding-based retriever
-        k=2,
-        # How many inference values to pass to model at once
-        batch_size=5,
-    )
+  LLMMap.from_args(
+    few_shot_examples=[
+      *DEFAULT_MAP_FEW_SHOT,
+      {
+        "question": "Is this a sport?",
+        "mapping": {
+          "Soccer": True,
+          "Chair": False,
+          "Banana": False,
+          "Golf": True
+        },
+        # Below are optional
+        "column_name": "Items",
+        "table_name": "Table",
+        "return_type": "boolean"
+      }
+    ],
+    num_few_shot_examples=2,
+    # How many inference values to pass to model at once
+    batch_size=5,
+  )
 }
 
 bsql = BlendSQL(db, ingredients=ingredients)
@@ -387,7 +386,7 @@ ingredients = {
             }
         ],
         # Will fetch `k` most relevant few-shot examples using embedding-based retriever
-        k=2,
+        num_few_shot_examples=2,
         # Lambda to turn the pd.DataFrame to a serialized string
         context_formatter=lambda df: df.to_markdown(
             index=False
@@ -407,23 +406,22 @@ from blendsql import BlendSQL
 from blendsql.ingredients.builtin import LLMJoin, DEFAULT_JOIN_FEW_SHOT
 
 ingredients = {
-    LLMJoin.from_args(
-        few_shot_examples=[
-            *DEFAULT_JOIN_FEW_SHOT,
-            {
-                "join_criteria": "Join the state to its capital.",
-                "left_values": ["California", "Massachusetts", "North Carolina"],
-                "right_values": ["Sacramento", "Boston", "Chicago"],
-                "mapping": {
-                    "California": "Sacramento",
-                    "Massachusetts": "Boston",
-                    "North Carolina": "-"
-                }
-            }
-        ],
-        # Will fetch `k` most relevant few-shot examples using embedding-based retriever
-        k=2
-    )
+  LLMJoin.from_args(
+    few_shot_examples=[
+      *DEFAULT_JOIN_FEW_SHOT,
+      {
+        "join_criteria": "Join the state to its capital.",
+        "left_values": ["California", "Massachusetts", "North Carolina"],
+        "right_values": ["Sacramento", "Boston", "Chicago"],
+        "mapping": {
+          "California": "Sacramento",
+          "Massachusetts": "Boston",
+          "North Carolina": "-"
+        }
+      }
+    ],
+    num_few_shot_examples=2
+  )
 }
 
 bsql = BlendSQL(db, ingredients=ingredients)

--- a/blendsql/ingredients/builtin/map/examples.py
+++ b/blendsql/ingredients/builtin/map/examples.py
@@ -3,7 +3,6 @@ import typing as t
 
 from blendsql.ingredients.few_shot import Example
 from blendsql.types import DataType, DataTypes, STR_TO_DATATYPE
-from blendsql.common.constants import DEFAULT_ANS_SEP
 
 
 @attrs(kw_only=True)
@@ -86,36 +85,3 @@ class ConstrainedAnnotatedMapExample(ConstrainedMapExample):
             s += f'\n\t\tf("{k}") == ' + (f'"{v}"' if isinstance(v, str) else f"{v}")
         s += '''\n\t\t```\n\t"""\n\t...'''
         return s
-
-
-# Below are for use with unconstrained models
-class UnconstrainedMapExample(MapExample):
-    def to_string(self, list_options: bool = True, *args, **kwargs) -> str:
-        s = f"\n\nQuestion: {self.question}\n"
-        if self.table_name is not None:
-            s += f"Source table: {self.table_name}\n"
-        if self.column_name is not None:
-            s += f"Source column: {self.column_name}\n"
-        if self.return_type is not None:
-            if self.return_type.name != "Any":
-                s += f"Output datatype: {self.return_type.name}\n"
-        # if self.example_outputs is not None:
-        #     s += f"Example outputs: {';'.join(self.example_outputs)}\n"
-        if list_options:
-            if self.options is not None:
-                s += f"Options: {','.join(sorted(self.options))}\n"
-        s += "\nValues:\n"
-        values = self.values
-        if self.values is None:
-            values = self.mapping.keys()
-        for _idx, k in enumerate(values):
-            s += f"{k}\n"
-        s += "\nAnswer: "
-        return s
-
-
-class UnconstrainedAnnotatedMapExample(UnconstrainedMapExample):
-    def to_string(self, list_options: bool = True, *args, **kwargs) -> str:
-        s = super().to_string(list_options=list_options, *args, **kwargs)
-        s += DEFAULT_ANS_SEP.join([str(i) for i in self.mapping.values()])
-        return s + "\n\n---"

--- a/blendsql/ingredients/builtin/map/examples.py
+++ b/blendsql/ingredients/builtin/map/examples.py
@@ -9,7 +9,6 @@ from blendsql.types import DataType, DataTypes, STR_TO_DATATYPE
 class MapExample(Example):
     question: str = attrib(default=None)
     context: t.Optional[str] = attrib(default=None)
-    values: t.Optional[t.List[str]] = attrib(default=None)
     table_name: str = attrib(default=None)
     column_name: str = attrib(default=None)
     options: t.Optional[t.Collection[str]] = attrib(default=None)

--- a/blendsql/ingredients/builtin/qa/main.py
+++ b/blendsql/ingredients/builtin/qa/main.py
@@ -88,7 +88,7 @@ class LLMQA(QAIngredient):
             index=False
         ),
         list_options_in_prompt: bool = True,
-        num_few_shot_examples: t.Optional[int] = None,
+        num_few_shot_examples: t.Optional[int] = 1,
         searcher: t.Optional[Searcher] = None,
     ):
         """Creates a partial class with predefined arguments.
@@ -152,7 +152,6 @@ class LLMQA(QAIngredient):
         few_shot_retriever = initialize_retriever(
             examples=few_shot_examples,
             num_few_shot_examples=num_few_shot_examples,
-            context_formatter=context_formatter,
         )
         return cls._maybe_set_name_to_var_name(
             partialclass(
@@ -210,7 +209,7 @@ class LLMQA(QAIngredient):
             )
         if few_shot_retriever is None:
             # Default to no few-shot examples in LLMQA
-            few_shot_retriever = lambda *_: []
+            few_shot_retriever = lambda *_: DEFAULT_QA_FEW_SHOT[:1]
 
         # If we explicitly passed `context`, this should take precedence over the vector store.
         if searcher is not None and context is None:

--- a/blendsql/ingredients/utils.py
+++ b/blendsql/ingredients/utils.py
@@ -4,20 +4,21 @@ from functools import partialmethod
 from .few_shot import Example
 
 # Can be:
-# - '{value1};{value2}...' syntax
-# - '{table}::{column}' syntax
+# - '{table}.{column}' syntax
 # - A BlendSQL query which returns a 1d array of values ((SELECT value FROM table WHERE ...))
 ValueArray = t.NewType("ValueArray", str)
 
 
 def initialize_retriever(
-    examples: t.List[Example], k: t.Optional[int] = None, **to_string_args
+    examples: t.List[Example],
+    num_few_shot_examples: t.Optional[int] = None,
+    **to_string_args,
 ) -> t.Callable[[str], t.List[Example]]:
     """Initializes a DPR retriever over the few-shot examples provided."""
-    if k == 0:
+    if num_few_shot_examples == 0:
         return lambda *_: []
     else:
-        return lambda *_: examples
+        return lambda *_: examples[:num_few_shot_examples]
     #
     # if k is None or k == len(examples):
     #     # Just return all the examples everytime this is called

--- a/blendsql/ingredients/utils.py
+++ b/blendsql/ingredients/utils.py
@@ -12,31 +12,12 @@ ValueArray = t.NewType("ValueArray", str)
 def initialize_retriever(
     examples: t.List[Example],
     num_few_shot_examples: t.Optional[int] = None,
-    **to_string_args,
 ) -> t.Callable[[str], t.List[Example]]:
     """Initializes a DPR retriever over the few-shot examples provided."""
     if num_few_shot_examples == 0:
         return lambda *_: []
     else:
         return lambda *_: examples[:num_few_shot_examples]
-    #
-    # if k is None or k == len(examples):
-    #     # Just return all the examples everytime this is called
-    #     return lambda *_: examples
-    # elif k == 0:
-    #     return lambda *_: []
-    #
-    # assert k <= len(
-    #     examples
-    # ), f"The `k` argument to an ingredient must be less than `len(few_shot_examples)`!\n`k` is {k}, `len(few_shot_examples)` is {len(examples)}"
-    # from blendsql.search.faiss_vector_store import FaissVectorStore
-    #
-    # retriever = FaissVectorStore(
-    #     documents=[example.to_string(**to_string_args) for example in examples],
-    #     return_objs=examples,
-    #     k=k,
-    # )
-    # return retriever
 
 
 def partialclass(cls, *args, **kwds):

--- a/blendsql/models/unconstrained/litellm.py
+++ b/blendsql/models/unconstrained/litellm.py
@@ -1,8 +1,8 @@
 import os
-from typing import Optional, List
+import typing as t
 from asyncio import Semaphore
 import asyncio
-from litellm import acompletion
+import dspy
 
 from blendsql.configure import ASYNC_LIMIT_KEY, DEFAULT_ASYNC_LIMIT
 from blendsql.models.model import UnconstrainedModel
@@ -33,7 +33,7 @@ class LiteLLM(UnconstrainedModel):
         self,
         model_name_or_path: str,
         env: str = ".",
-        config: Optional[dict] = None,
+        config: t.Optional[dict] = None,
         caching: bool = True,
         **kwargs,
     ):
@@ -51,37 +51,40 @@ class LiteLLM(UnconstrainedModel):
 
     async def _generate(
         self,
-        messages_list: List[List[dict]],
-        max_tokens: Optional[int] = None,
-        stop_at: Optional[List[str]] = None,
-        **kwargs,
+        dspy_predict: dspy.Predict,
+        kwargs_list: t.List[t.List[dict]],
+        max_tokens: t.Optional[int] = None,
+        stop: t.Optional[t.List[str]] = None,
     ):
         sem = Semaphore(int(os.getenv(ASYNC_LIMIT_KEY, DEFAULT_ASYNC_LIMIT)))
+        dspy.configure(
+            lm=dspy.LM(
+                self.model_name_or_path,
+                {**{"max_tokens": max_tokens, "stop": stop}, **self.config},
+            )
+        )
+
         async with sem:
             responses = [
-                acompletion(
-                    model=self.model_name_or_path,
-                    messages=messages,
-                    max_tokens=max_tokens,
-                    stop=stop_at,
-                    **self.config,
-                )
-                for messages in messages_list
+                dspy_predict.acall(model=self.model_name_or_path, **kwargs)
+                for kwargs in kwargs_list
             ]
             return [m for m in await asyncio.gather(*responses)]
 
-    def generate(self, *args, **kwargs) -> List[str]:
+    def generate(
+        self,
+        dspy_predict: dspy.Predict,
+        kwargs_list: t.List[t.List[dict]],
+        *args,
+        **kwargs,
+    ) -> t.List[str]:
         """Handles cache lookup and generation using LiteLLM."""
-        responses, key = None, None
-        if self.caching:
-            responses, key = self.check_cache(*args, **kwargs)
-        if responses is None:
-            responses = asyncio.get_event_loop().run_until_complete(
-                self._generate(*args, **kwargs)
-            )  # type: ignore
-            self.num_generation_calls += 1
-        self.prompt_tokens += sum([r.usage.prompt_tokens for r in responses])
-        self.completion_tokens += sum([r.usage.completion_tokens for r in responses])
-        if self.caching:
-            self.cache[key] = responses
-        return [r.choices[0].message.content for r in responses]
+        responses = asyncio.get_event_loop().run_until_complete(
+            self._generate(dspy_predict, kwargs_list, *args, **kwargs)
+        )  # type: ignore
+        for call in dspy.settings.lm.history[-len(kwargs_list) :]:
+            self.num_generation_calls += bool(call["usage"] != {})
+            if call["usage"] != dict():
+                self.prompt_tokens += call["usage"]["prompt_tokens"]
+                self.completion_tokens += call["usage"]["completion_tokens"]
+        return [r.answer for r in responses]

--- a/blendsql/types/types.py
+++ b/blendsql/types/types.py
@@ -68,7 +68,7 @@ class DataTypes:
         "float", r"(\d+(\.\d+)?)", quantifier, str_to_numeric
     )
     NUMERIC = lambda quantifier=None: DataType(
-        "t.Union[int, float]", r"(\d+(\.\d+)?)", quantifier, str_to_numeric
+        "Union[int, float]", r"(\d+(\.\d+)?)", quantifier, str_to_numeric
     )
     ISO_8601_DATE = lambda quantifier=None: DataType(
         "date", r"\d{4}-\d{2}-\d{2}", quantifier, lambda s: s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "numpy<2",
     "bm25s"
 ]
-version = "0.0.40"
+version = "0.0.41"
 
 [project.urls]
 Documentation = "https://parkervg.github.io/blendsql/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "guidance==0.1.16",
     "transformers==4.47.0",
     "accelerate==1.5.2",
-    "litellm",
+    "dspy",
     "pandas>=2.0.0",
     "bottleneck>=1.3.6",
     "python-dotenv==1.0.1",

--- a/research/run-evaluate.py
+++ b/research/run-evaluate.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # )
     ingredients = {
         LLMQA.from_args(
-            k=0,
+            num_few_shot_examples=0,
             context_formatter=lambda df: json.dumps(
                 df.to_dict(orient="records"), indent=4
             ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,12 +56,11 @@ CONSTRAINED_MODEL_CONFIGS = [
 ]
 
 UNCONSTRAINED_MODEL_CONFIGS = [
-    {
-        "name": "ollama",
-        "class": LiteLLM,
-        "path": "ollama/qwen:0.5b",
-        "requires_api": False,
-    },
+    # {
+    #     "name": "ollama",
+    #     "class": LiteLLM,
+    #     "path": "ollama/qwen:0.5b",
+    # },
     {
         "name": "openai",
         "class": LiteLLM,
@@ -101,7 +100,10 @@ def get_available_constrained_models():
 def get_available_unconstrained_models():
     available_models = []
     for config in UNCONSTRAINED_MODEL_CONFIGS:
-        if config.get("requires_env") and os.getenv(config["requires_env"]) is None:
+        if (
+            config.get("requires_env")
+            and os.getenv(config["requires_env"], None) is None
+        ):
             continue
 
         model = config["class"](config["path"], caching=False)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -73,7 +73,7 @@ def test_error_on_bad_options_subquery(bsql):
 
 def test_replacement_scan(bsql, constrained_model):
     """ad94437"""
-    NewIngredient = LLMQA.from_args(k=2)
+    NewIngredient = LLMQA.from_args(num_few_shot_examples=2)
     _ = bsql.execute(
         """
         SELECT * FROM w 


### PR DESCRIPTION
It got to be a hassle to maintain both structured + unstructured prompts, and [dspy](https://github.com/stanfordnlp/dspy) seems to be a good fit. 

For example, we now write:

```python
qa_fn = dspy.Predict(
    dspy.Signature(
        f"question: str, context: Optional[str] -> answer: {return_type_annotation}",
        instructions=instructions,
    )
)
qa_fn.demos = [
    dspy.Example(
        {
            "question": example.question,
            "context": context_formatter(example.context),
            "answer": example.answer,
        }
    )
    for example in few_shot_examples
]
```